### PR TITLE
FAdd a minor fix for the b:plist_original_format;

### DIFF
--- a/autoload/plist.vim
+++ b/autoload/plist.vim
@@ -66,6 +66,7 @@ endfunction
 function! plist#Write()
   " Cache the argument filename destination
   let filename = resolve(expand('<afile>'))
+  let b:plist_original_format = plist#GetOriginalFormat()
 
   " If the user has not specified his preferred format when saving, use the
   " same format as the file had originally. Otherwise the user option takes
@@ -110,7 +111,14 @@ function! plist#ReadPost()
   call plist#SetFiletype()
 endfunction
 
+function! plist#GetOriginalFormat()
+  let filename = expand('<afile>')
+  return plist#DetectFormat(filename)
+endfunction
+
+
 function! plist#SetFiletype()
+  let b:plist_original_format = plist#GetOriginalFormat()
   if g:plist_display_format == 'json' && s:has_plist || b:plist_original_format == 'json' && !s:has_plist
     execute 'set filetype=' . (len(getcompletion('json', 'filetype')) ? 'json' : 'javascript')
   else


### PR DESCRIPTION
Hi darfink!
First of all, thank you for the plugin, it is really useful.
I have encountered an issue with g:plist_original_format variable in the following context:
the autogroup in the plugin file calls plist#SetFiletype() and then checks if the file format is set to json. because i originally had it set to xml, i was receiving an error complaining about the b:plist_original_fromat not having been set. same with write..
This is introduced just a tiny fix for those situations; I would be ver glad if you choose to accept this pr.
Cheers,
axrt